### PR TITLE
General: Alternative buildsystem using just instead of ant

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[{*.sh,*.bash}]
+[{*.sh,*.bash,justfile}]
 indent_style = space
 indent_size = 2
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2025 Move Agency Group B.V., Zwolle, The Netherlands
+# SPDX-License-Identifier: CC0-1.0
+
+import x'$LUNR_JUSTFILES/common.justfile'
+
+set allow-duplicate-variables
+
+export github_actions := env('GITHUB_ACTIONS', '0')
+export default_coding_standard := env('LUNR_CODING_STANDARD', '/var/www/libs/lunr-coding-standard/Lunr/')
+
+setup type='dev': (decomposer type)


### PR DESCRIPTION
## How to Test:

- Install [just](https://github.com/casey/just)
- Clone the shared justfiles from https://github.com/lunr-php/justfiles
- Configure 2 environment variables:
	- *LUNR_JUSTFILES*: Path to the git clone of the shared justfiles
	- *LUNR_CODING_STANDARD*: Path to the git clone of the lunr coding standard (if it's somewhere other than `/var/www/libs/lunr-coding-standard/Lunr`)
	
`just -l` shows you all the different "build targets" that are available. For example:

```just phpstan```
Runs phpstan with the same config as CI would

```just phpstan 9```
Runs phpstan with level 9 instead of the default level

```just phpcs```
Runs phpcs with the same config as CI would

```just phpcs PSR12```
Checks the code against the PSR12 coding standard