### PR TITLE
PHPStan: Change phpstan extensions to read recipes as string

### DIFF
--- a/src/Lunr/Core/PHPStan/ConfigServiceLocatorAsContainerInterfaceMethodReturnTypeExtension.php
+++ b/src/Lunr/Core/PHPStan/ConfigServiceLocatorAsContainerInterfaceMethodReturnTypeExtension.php
@@ -41,18 +41,6 @@ class ConfigServiceLocatorAsContainerInterfaceMethodReturnTypeExtension extends 
         return !in_array($methodReflection->getName(), [ 'has' ]);
     }
 
-    /**
-     * Catch locator get calls in the locate files
-     *
-     * @param string $name Name of the locator
-     *
-     * @return void
-     */
-    public function get(string $name): void
-    {
-        //NO-OP
-    }
-
 }
 
 ?>

--- a/src/Lunr/Core/PHPStan/ConfigServiceLocatorMethodReturnTypeExtension.php
+++ b/src/Lunr/Core/PHPStan/ConfigServiceLocatorMethodReturnTypeExtension.php
@@ -79,19 +79,41 @@ class ConfigServiceLocatorMethodReturnTypeExtension implements DynamicMethodRetu
         /** @var LocatorRecipe $recipe */
         $recipe = [];
         $path   = 'locator/locate.' . $id . '.inc.php';
-        if (stream_resolve_include_path($path) === FALSE)
+        $file   = stream_resolve_include_path($path);
+
+        if ($file === FALSE)
         {
             return NULL;
         }
 
-        include_once $path;
+        $class = NULL;
 
-        if (!isset($recipe[$id]['name']))
+        $handle = fopen($file, 'r');
+        if ($handle !== FALSE)
+        {
+            while (($line = fgets($handle)) !== FALSE)
+            {
+                if (str_contains($line, '$recipe[\'' . $id . '\'][\'name\']'))
+                {
+                    preg_match("/=\s*'([^']+)'/", $line, $matches);
+                    if (isset($matches[1]))
+                    {
+                        $class = $matches[1];
+                    }
+
+                    break;
+                }
+            }
+
+            fclose($handle);
+        }
+
+        if ($class === NULL)
         {
             return NULL;
         }
 
-        return new ObjectType($recipe[$id]['name']);
+        return new ObjectType($class);
     }
 
 }


### PR DESCRIPTION
This fixes issues with having to execute more complex code in recipes that is not relevant to what we need for the extension