### PR TITLE
PHPStan: Remove unused variable

### DIFF
--- a/src/Lunr/Core/PHPStan/ConfigServiceLocatorMethodReturnTypeExtension.php
+++ b/src/Lunr/Core/PHPStan/ConfigServiceLocatorMethodReturnTypeExtension.php
@@ -76,10 +76,8 @@ class ConfigServiceLocatorMethodReturnTypeExtension implements DynamicMethodRetu
             }
         }
 
-        /** @var LocatorRecipe $recipe */
-        $recipe = [];
-        $path   = 'locator/locate.' . $id . '.inc.php';
-        $file   = stream_resolve_include_path($path);
+        $path = 'locator/locate.' . $id . '.inc.php';
+        $file = stream_resolve_include_path($path);
 
         if ($file === FALSE)
         {


### PR DESCRIPTION
Left over from before the rework to read recipes as string