### PR TITLE
CI: Increase phpstan to level 6

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -9,7 +9,7 @@ jobs:
   php-tests:
     uses: lunr-php/actions-templates/.github/workflows/php-composer.yml@master
     with:
-      phpstan-level: 5
+      phpstan-level: 6
       allow-style-failures: false
       allow-phpstan-failures: false
       codestyle-branch: '0.11.0'

--- a/src/Lunr/Core/ConfigServiceLocator.php
+++ b/src/Lunr/Core/ConfigServiceLocator.php
@@ -85,8 +85,8 @@ class ConfigServiceLocator implements ContainerInterface
     /**
      * Instantiate a new object by ID.
      *
-     * @param string $id        ID of the object to instantiate
-     * @param array  $arguments Arguments passed on call (Ignored)
+     * @param string  $id        ID of the object to instantiate
+     * @param mixed[] $arguments Arguments passed on call (Ignored)
      *
      * @return object|null New Object or NULL if the ID is unknown.
      */
@@ -300,10 +300,10 @@ class ConfigServiceLocator implements ContainerInterface
     /**
      * Prepare the parameters in the recipe for object instantiation.
      *
-     * @param array                 $params       Array of parameters according to the recipe.
+     * @param mixed[]               $params       Array of parameters according to the recipe.
      * @param ReflectionParameter[] $methodParams Array of ReflectionParameters for the method
      *
-     * @return array Array of processed parameters ready for instantiation.
+     * @return mixed[] Array of processed parameters ready for instantiation.
      */
     protected function getParameters(array $params, array $methodParams): array
     {

--- a/src/Lunr/Core/PHPStan/ConfigServiceLocatorRecipeReflectionExtension.php
+++ b/src/Lunr/Core/PHPStan/ConfigServiceLocatorRecipeReflectionExtension.php
@@ -23,14 +23,14 @@ class ConfigServiceLocatorRecipeReflectionExtension implements MethodsClassRefle
 {
     /**
      * List of locators that are pre-set
-     * @var array
+     * @var string[]
      */
     private array $presetList = [ 'config' ];
 
     /**
      * Constructor for ConfigServiceLocatorRecipeReflectionExtension.
      *
-     * @param array $presetList List of pre-set locator recipes.
+     * @param string[] $presetList List of pre-set locator recipes.
      */
     public function __construct(array $presetList = [])
     {

--- a/tests/phpstan.neon.dist
+++ b/tests/phpstan.neon.dist
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 parameters:
-    level: 5
+    level: 6
     paths:
         - ../src
     bootstrapFiles:


### PR DESCRIPTION
Unfortunately, `mixed` is really the best we can do here, since
method parameters can be any type.